### PR TITLE
Fix icon ImageResponse import for Next 15

### DIFF
--- a/src/app/icon.tsx
+++ b/src/app/icon.tsx
@@ -1,4 +1,4 @@
-import { ImageResponse } from 'next/server';
+import { ImageResponse } from 'next/og';
 
 export const size = {
   width: 96,


### PR DESCRIPTION
## Summary
- update the app icon generator to import ImageResponse from `next/og` now that Next.js 15 no longer exports it from `next/server`

## Testing
- npm run build *(fails: Next.js cannot download Google Fonts due to network restrictions in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0e6182b34832d9838ea8decf843bb