### PR TITLE
Fix Next.js icon generation compatibility

### DIFF
--- a/src/app/icon.tsx
+++ b/src/app/icon.tsx
@@ -1,32 +1,29 @@
-import { ImageResponse } from 'next/og';
+import type { CSSProperties } from "react";
+import { ImageResponse } from "next/og";
 
 export const size = {
   width: 96,
   height: 96,
 };
 
-export const contentType = 'image/png';
+export const contentType = "image/png";
+
+const iconStyle: CSSProperties = {
+  display: "flex",
+  height: "100%",
+  width: "100%",
+  alignItems: "center",
+  justifyContent: "center",
+  background: "radial-gradient(circle at 30% 30%, #f97316, #1f2937)",
+  color: "#f9fafb",
+  fontSize: 52,
+  fontWeight: 700,
+  letterSpacing: -2,
+};
 
 export default function Icon() {
   return new ImageResponse(
-    (
-      <div
-        style={{
-          display: 'flex',
-          height: '100%',
-          width: '100%',
-          alignItems: 'center',
-          justifyContent: 'center',
-          background: 'radial-gradient(circle at 30% 30%, #f97316, #1f2937)',
-          color: '#f9fafb',
-          fontSize: 52,
-          fontWeight: 700,
-          letterSpacing: -2,
-        }}
-      >
-        AM
-      </div>
-    ),
+    <div style={iconStyle}>AM</div>,
     {
       ...size,
     }


### PR DESCRIPTION
## Summary
- import `ImageResponse` from `next/og` and share the icon style configuration

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0eb098598832d99aaa5409a23268e