### PR TITLE
Fix promise-based params typing in task route handler

### DIFF
--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -2,7 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { baseTaskSchema, dependencySchema } from '@/utils/validation';
 import { deleteTask, getTask, updateTask, upsertDependencies } from '@/lib/tasks';
 
-type RouteContext = { params: Promise<{ id: string }> };
+type RouteParams = { id: string };
+type RouteContext = { params: RouteParams | Promise<RouteParams> };
 
 async function parseTaskId(context: RouteContext) {
   const { id } = await context.params;


### PR DESCRIPTION
## Summary
- update the task API route handler context typing to accept promise-based params introduced in Next.js 15
- keep the existing logic that awaits the route params for compatibility with both promised and direct params

## Testing
- npm run build *(fails in this environment when fetching Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68e0f6e69b58832d832aac6b1079bf04