### PR TITLE
Fix task API route context typing for Next.js 15

### DIFF
--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -3,7 +3,7 @@ import { baseTaskSchema, dependencySchema } from '@/utils/validation';
 import { deleteTask, getTask, updateTask, upsertDependencies } from '@/lib/tasks';
 
 type RouteParams = { id: string };
-type RouteContext = { params: RouteParams | Promise<RouteParams> };
+type RouteContext = { params: Promise<RouteParams> };
 
 async function parseTaskId(context: RouteContext) {
   const { id } = await context.params;


### PR DESCRIPTION
## Summary
- align the dynamic task API route handler with Next.js 15's promised params type

## Testing
- npm run build *(fails: Turbopack cannot fetch Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0fbd8c164832db74648b7db66adf5