### PR TITLE
Fix CSV export typing

### DIFF
--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -6,7 +6,7 @@ import * as XLSX from 'xlsx';
 
 function buildCsv(rows: Task[]): string {
   if (!rows.length) return '';
-  const headers = Object.keys(rows[0] as Record<string, unknown>);
+  const headers = Object.keys(rows[0]) as (keyof Task)[];
   const escape = (value: unknown) => {
     if (value === null || value === undefined) return '';
     const str = String(value).replace(/"/g, '""');
@@ -14,8 +14,7 @@ function buildCsv(rows: Task[]): string {
   };
   const lines = [headers.join(',')];
   rows.forEach((row) => {
-    const record = row as Record<string, unknown>;
-    lines.push(headers.map((header) => escape(record[header])).join(','));
+    lines.push(headers.map((header) => escape(row[header])).join(','));
   });
   return lines.join('\n');
 }


### PR DESCRIPTION
## Summary
- infer CSV headers from Task keys without forcing a Record cast
- remove unnecessary Record coercion when serializing rows

## Testing
- npm run build *(fails: next/font unable to download Geist / Geist Mono in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e105094908832d83a3e0a37ca4eefe