### PR TITLE
Fix line chart tension options

### DIFF
--- a/src/app/api/export/route.ts
+++ b/src/app/api/export/route.ts
@@ -6,7 +6,7 @@ import * as XLSX from 'xlsx';
 
 function buildCsv(rows: Task[]): string {
   if (!rows.length) return '';
-  const headers = Object.keys(rows[0] as Record<string, unknown>);
+  const headers = Object.keys(rows[0]) as (keyof Task)[];
   const escape = (value: unknown) => {
     if (value === null || value === undefined) return '';
     const str = String(value).replace(/"/g, '""');
@@ -14,8 +14,7 @@ function buildCsv(rows: Task[]): string {
   };
   const lines = [headers.join(',')];
   rows.forEach((row) => {
-    const record = row as Record<string, unknown>;
-    lines.push(headers.map((header) => escape(record[header])).join(','));
+    lines.push(headers.map((header) => escape(row[header])).join(','));
   });
   return lines.join('\n');
 }

--- a/src/components/DashboardOverview.tsx
+++ b/src/components/DashboardOverview.tsx
@@ -68,6 +68,7 @@ export function DashboardOverview() {
           data: counts,
           borderColor: '#6366f1',
           backgroundColor: 'rgba(99, 102, 241, 0.2)',
+          tension: 0.3,
         },
       ],
     };
@@ -161,7 +162,7 @@ export function DashboardOverview() {
         <div className="grid gap-6 lg:grid-cols-2">
           <div className="rounded-2xl border border-slate-200/70 bg-white/80 p-5 shadow-inner">
             <h3 className="text-sm font-semibold text-slate-600">週次登録数推移</h3>
-            <Line data={weeklyTrend} options={{ tension: 0.3 }} />
+            <Line data={weeklyTrend} options={{ elements: { line: { tension: 0.3 } } }} />
           </div>
           <div className="rounded-2xl border border-slate-200/70 bg-white/80 p-5 shadow-inner">
             <h3 className="text-sm font-semibold text-slate-600">月次登録数推移</h3>


### PR DESCRIPTION
## Summary
- move line tension configuration to the dataset and chart options for the weekly trend graph
- ensure the weekly line chart uses the supported Chart.js options structure

## Testing
- npm run build *(fails: next/font cannot download Geist / Geist Mono in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e105094908832d83a3e0a37ca4eefe