### PR TITLE
Improve SQLite path resolution for file URIs

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,9 +1,49 @@
 import Database from 'better-sqlite3';
 import { sql } from '@vercel/postgres';
+import { mkdirSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 export type QueryParam = string | number | boolean | null;
 
-const SQLITE_PATH = process.env.SQLITE_DB_PATH || 'dev.db';
+const SQLITE_PATH = resolveSqlitePath(process.env.SQLITE_DB_PATH || 'dev.db');
+
+function resolveSqlitePath(sqlitePath: string): string {
+  if (sqlitePath === ':memory:' || sqlitePath.startsWith('file::memory:')) {
+    return sqlitePath;
+  }
+
+  let normalizedPath = sqlitePath;
+
+  if (normalizedPath.startsWith('~')) {
+    normalizedPath = path.join(os.homedir(), normalizedPath.slice(1));
+  }
+
+  if (normalizedPath.startsWith('file:')) {
+    ensureFileUriDirectory(normalizedPath);
+    return normalizedPath;
+  }
+
+  const resolved = path.isAbsolute(normalizedPath)
+    ? normalizedPath
+    : path.resolve(process.cwd(), normalizedPath);
+  mkdirSync(path.dirname(resolved), { recursive: true });
+  return resolved;
+}
+
+function ensureFileUriDirectory(uri: string) {
+  try {
+    const base = pathToFileURL(process.cwd() + path.sep);
+    const fileUrl = new URL(uri, base);
+    const fsPath = fileURLToPath(fileUrl);
+    if (fsPath) {
+      mkdirSync(path.dirname(fsPath), { recursive: true });
+    }
+  } catch {
+    // Ignore malformed URIs and let SQLite surface the error instead.
+  }
+}
 
 function toPostgresQuery(query: string): string {
   let index = 0;


### PR DESCRIPTION
## Summary
- expand tilde-prefixed SQLite paths to the current user's home directory
- ensure directories exist for SQLite file URIs resolved relative to the project root
- keep in-memory connections untouched while leaving the migration flow unchanged

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2717df228832db56364dee2a0decd